### PR TITLE
style: 调整主页为 Apple 风格视觉

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,121 +3,59 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>个人主页</title>
+    <title>mfcheer · Backend Engineer</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <!-- 主容器 -->
+    <div class="page-bg"></div>
     <div class="container">
-        <!-- 顶部导航 -->
-        <nav class="navbar">
-            <div class="nav-logo">
-                <h1>mfcheer</h1>
-            </div>
-            <ul class="nav-links">
-                <li><a href="#about">关于</a></li>
-                <li><a href="#skills">技能</a></li>
-                <li><a href="#contact">联系</a></li>
-            </ul>
-        </nav>
+        <header class="topbar">
+            <a class="brand" href="#about">mfcheer</a>
+            <nav>
+                <ul class="nav-links">
+                    <li><a href="#about">关于</a></li>
+                    <li><a href="#skills">技能</a></li>
+                    <li><a href="#contact">联系</a></li>
+                </ul>
+            </nav>
+        </header>
 
-        <!-- Hero 部分 -->
-        <section class="hero" id="about">
-            <div class="hero-content">
-                <h1 class="hero-title">
-                    <span class="gradient-text">后端开发者</span>
-                </h1>
-                <p class="hero-subtitle">用代码创造美好的互联网体验</p>
-                <p class="hero-description">
-                    热爱技术 | 追求创新 | 专注用户体验
-                </p>
+        <main>
+            <section class="hero glass" id="about">
+                <p class="eyebrow">Backend Engineer</p>
+                <h1>构建稳定、优雅、值得信赖的后端系统。</h1>
+                <p class="intro">专注高并发服务、数据链路与业务架构优化，用简洁的技术方案支撑长期增长。</p>
                 <div class="hero-cta">
-                    <a href="#contact" class="btn btn-primary">联系我</a>
-                    <a href="#skills" class="btn btn-secondary">了解更多</a>
+                    <a class="btn btn-primary" href="#contact">联系我</a>
+                    <a class="btn btn-secondary" href="#skills">查看技能</a>
                 </div>
-            </div>
-            <div class="hero-visual">
-                <div class="floating-card card-1">
+            </section>
+
+            <section class="section glass" id="skills">
+                <h2>核心能力</h2>
+                <div class="chips">
                     <span>Go</span>
-                </div>
-                <div class="floating-card card-1">
                     <span>Python</span>
-                </div>
-                <div class="floating-card card-1">
-                    <span>数据流处理</span>
-                </div>
-                <div class="floating-card card-2">
-                    <span>数据存储</span>
-                </div>
-                <div class="floating-card card-3">
-                    <span>高吞吐系统</span>
-                </div>
-                <div class="floating-card card-4">
-                    <span>机器学习</span>
-                </div>
-                <div class="floating-card card-1">
-                    <span>大数据技术</span>
-                </div>
-                <div class="floating-card card-5">
                     <span>MySQL</span>
-                </div>
-                <div class="floating-card card-6">
-                    <span>MQ</span>
-                </div>
-                <div class="floating-card card-7">
-                    <span>KV存储</span>
-                </div>
-                <div class="floating-card card-8">
+                    <span>消息队列</span>
+                    <span>KV 存储</span>
+                    <span>高吞吐系统</span>
                     <span>推荐系统</span>
                 </div>
-                <div class="floating-card card-9">
-                    <span>广告业务</span>
-                </div>
-                <div class="floating-card card-10">
-                    <span>房产业务</span>
-                </div>
-            </div>
-        </section>
+            </section>
 
-        <!-- 个人信息部分 -->
-        <section class="about-section">
-            <h2>关于我</h2>
-            <div class="about-content">
-                <div class="about-text">
-                    <p> 资深工程师 | 热爱新技术 | 追求代码优雅</p>
-                    <p> 专注 后端开发、系统架构设计</p>
+            <section class="section glass" id="contact">
+                <h2>保持联系</h2>
+                <p class="intro">欢迎交流工程实践、系统设计与业务增长。</p>
+                <div class="contact-links">
+                    <a href="mailto:mfcheer@qq.com">✉︎ mfcheer@qq.com</a>
+                    <a href="https://github.com/mfcheer" target="_blank" rel="noreferrer">GitHub</a>
+                    <a href="https://linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
                 </div>
-            </div>
-        </section>
+            </section>
+        </main>
 
-        <!-- 联系方式 -->
-        <section class="contact-section" id="contact">
-            <h2>📬 联系我</h2>
-            <p class="contact-subtitle">期待与你相识</p>
-            <div class="contact-links">
-                <a href="mfcheer@qq.com" class="contact-btn">
-                    <span class="contact-icon">✉</span>
-                    <span>发送邮件</span>
-                </a>
-                <a href="https://github.com/mfcheer" target="_blank" class="contact-btn">
-                    <span class="contact-icon">💻</span>
-                    <span>GitHub</span>
-                </a>
-                <a href="https://linkedin.com" target="_blank" class="contact-btn">
-                    <span class="contact-icon">🔗</span>
-                    <span>LinkedIn</span>
-                </a>
-                <a href="https://twitter.com" target="_blank" class="contact-btn">
-                    <span class="contact-icon">𝕏</span>
-                    <span>Twitter</span>
-                </a>
-            </div>
-        </section>
-
-        <!-- 页脚 -->
-        <footer class="footer">
-            <p>💫 Build with love | © 2026 All rights reserved</p>
-        </footer>
+        <footer class="footer">Designed with -inspired simplicity · © 2026 mfcheer</footer>
     </div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,47 +1,13 @@
-// 平滑滚动锚点
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-    anchor.addEventListener('click', function (e) {
-        e.preventDefault();
-        const target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-            target.scrollIntoView({ behavior: 'smooth' });
+document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+    anchor.addEventListener('click', (event) => {
+        const targetId = anchor.getAttribute('href');
+        const target = document.querySelector(targetId);
+
+        if (!target) {
+            return;
         }
+
+        event.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 });
-
-// 页面加载动画
-window.addEventListener('load', () => {
-    document.querySelectorAll('.skill-card, .stat-item').forEach((el, index) => {
-        el.style.opacity = '0';
-        el.style.animation = `fadeInUp 0.6s ease-out ${index * 0.1}s forwards`;
-    });
-});
-
-// 添加动画关键帧
-const style = document.createElement('style');
-style.textContent = `
-    @keyframes fadeInUp {
-        from {
-            opacity: 0;
-            transform: translateY(30px);
-        }
-        to {
-            opacity: 1;
-            transform: translateY(0);
-        }
-    }
-`;
-document.head.appendChild(style);
-
-// 导航栏背景在滚动时变暗
-window.addEventListener('scroll', () => {
-    const navbar = document.querySelector('.navbar');
-    if (window.scrollY > 0) {
-        navbar.style.background = 'rgba(15, 23, 42, 0.95)';
-    } else {
-        navbar.style.background = 'rgba(15, 23, 42, 0.8)';
-    }
-});
-
-console.log('%c💫 Welcome to Portfolio', 'font-size: 20px; color: #00d4ff; font-weight: bold;');
-console.log('%cPowered by Modern Web Design', 'font-size: 14px; color: #94a3b8;');

--- a/styles.css
+++ b/styles.css
@@ -1,370 +1,224 @@
 * {
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
-    box-sizing: border-box;
 }
 
 :root {
-    --primary: #00d4ff;
-    --secondary: #ff1493;
-    --dark-bg: #0f172a;
-    --light-text: #e2e8f0;
-    --gray-text: #94a3b8;
+    --bg: #f5f5f7;
+    --surface: rgba(255, 255, 255, 0.72);
+    --text: #1d1d1f;
+    --muted: #6e6e73;
+    --line: rgba(0, 0, 0, 0.08);
+    --accent: #0071e3;
+    --shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
 }
 
-html {
+html,
+body {
     scroll-behavior: smooth;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-    background: linear-gradient(135deg, var(--dark-bg) 0%, #1a1f35 100%);
-    color: var(--light-text);
+    font-family: "SF Pro Text", "PingFang SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+    color: var(--text);
+    background: var(--bg);
+    min-height: 100vh;
     line-height: 1.6;
+}
+
+.page-bg {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background:
+        radial-gradient(circle at 10% 20%, rgba(0, 113, 227, 0.08), transparent 35%),
+        radial-gradient(circle at 90% 10%, rgba(175, 82, 222, 0.08), transparent 30%),
+        linear-gradient(180deg, #fbfbfd 0%, #f5f5f7 100%);
 }
 
 .container {
-    max-width: 1200px;
+    max-width: 920px;
     margin: 0 auto;
-    padding: 0 20px;
+    padding: 24px;
 }
 
-/* 导航栏 */
-.navbar {
+.topbar {
+    position: sticky;
+    top: 14px;
+    z-index: 10;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 15px 0;
-    position: sticky;
-    top: 0;
-    background: rgba(15, 23, 42, 0.8);
-    backdrop-filter: blur(10px);
-    z-index: 100;
+    padding: 13px 18px;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.78);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
 }
 
-.nav-logo h1 {
-    font-size: 24px;
-    background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    font-weight: 700;
+.brand {
+    text-decoration: none;
+    color: var(--text);
+    font-weight: 600;
+    letter-spacing: -0.02em;
 }
 
 .nav-links {
-    display: flex;
     list-style: none;
-    gap: 30px;
+    display: flex;
+    gap: 18px;
 }
 
 .nav-links a {
-    color: var(--light-text);
     text-decoration: none;
-    font-weight: 500;
+    color: var(--muted);
     font-size: 14px;
-    transition: color 0.3s ease;
+    transition: color 0.2s ease;
 }
 
 .nav-links a:hover {
-    color: var(--primary);
+    color: var(--text);
 }
 
-/* Hero 部分 */
-.hero {
+main {
+    margin-top: 26px;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 40px;
-    align-items: center;
-    padding: 60px 0;
+    gap: 18px;
 }
 
-.hero-content h1 {
-    font-size: 48px;
-    line-height: 1.2;
-    margin-bottom: 12px;
-    font-weight: 700;
+.glass {
+    background: var(--surface);
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    border-radius: 28px;
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
 }
 
-.gradient-text {
-    background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+.hero,
+.section {
+    padding: 34px;
 }
 
-.hero-subtitle {
-    font-size: 18px;
-    color: var(--gray-text);
+.eyebrow {
+    color: var(--accent);
+    font-size: 14px;
+    font-weight: 600;
     margin-bottom: 8px;
 }
 
-.hero-description {
-    font-size: 14px;
-    color: var(--gray-text);
-    margin-bottom: 20px;
+h1 {
+    font-size: clamp(32px, 5vw, 50px);
+    line-height: 1.2;
+    letter-spacing: -0.03em;
+    margin-bottom: 14px;
+}
+
+h2 {
+    font-size: 24px;
+    letter-spacing: -0.02em;
+    margin-bottom: 12px;
+}
+
+.intro {
+    color: var(--muted);
+    max-width: 62ch;
 }
 
 .hero-cta {
+    margin-top: 20px;
     display: flex;
-    gap: 12px;
+    gap: 10px;
 }
 
 .btn {
-    padding: 10px 24px;
-    border-radius: 6px;
-    border: none;
-    font-size: 14px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    text-decoration: none;
     display: inline-block;
+    padding: 10px 16px;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 14px;
+    border: 1px solid transparent;
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
-    color: white;
-}
-
-.btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(0, 212, 255, 0.2);
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 10px 20px rgba(0, 113, 227, 0.24);
 }
 
 .btn-secondary {
-    background: transparent;
-    color: var(--primary);
-    border: 1px solid var(--primary);
+    border-color: var(--line);
+    color: var(--text);
+    background: rgba(255, 255, 255, 0.75);
 }
 
-.btn-secondary:hover {
-    background: var(--primary);
-    color: white;
-}
-
-/* Hero 视觉 */
-.hero-visual {
+.chips {
     display: flex;
     flex-wrap: wrap;
-    gap: 16px;
-    align-content: flex-start;
+    gap: 10px;
 }
 
-.floating-card {
-    padding: 12px 20px;
-    border-radius: 8px;
-    background: rgba(0, 212, 255, 0.08);
-    border: 1px solid var(--primary);
-    color: var(--primary);
-    font-weight: 600;
+.chips span {
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 7px 12px;
     font-size: 13px;
-    animation: float 3s ease-in-out infinite;
-    white-space: nowrap;
-}
-
-.card-1 {
-    animation-delay: 0s;
-}
-
-.card-2 {
-    animation-delay: 0.3s;
-}
-
-.card-3 {
-    animation-delay: 0.6s;
-}
-
-.card-4 {
-    animation-delay: 0.9s;
-}
-
-.card-5 {
-    animation-delay: 1.2s;
-}
-
-.card-6 {
-    animation-delay: 1.5s;
-}
-
-.card-7 {
-    animation-delay: 1.8s;
-}
-
-.card-4 {
-    top: 160px;
-    left: 80px;
-    animation-delay: 1.5s;
-}
-
-.card-5 {
-    bottom: 20px;
-    right: 60px;
-    animation-delay: 2s;
-}
-
-.card-6 {
-    top: 80px;
-    right: 10px;
-    animation-delay: 0.3s;
-}
-
-@keyframes float {
-    0%, 100% {
-        transform: translateY(0);
-    }
-    50% {
-        transform: translateY(-15px);
-    }
-}
-
-/* 关于部分 */
-.about-section {
-    padding: 20px 0;
-}
-
-.about-section h2 {
-    font-size: 20px;
-    margin-bottom: 12px;
-    text-align: center;
-}
-
-.about-content {
-    text-align: center;
-}
-
-.about-text p {
-    font-size: 13px;
-    color: var(--gray-text);
-    margin-bottom: 4px;
-    line-height: 1.6;
-}
-
-/* 技能部分 */
-.skills-section {
-    display: none;
-}
-
-/* 联系部分 */
-.contact-section {
-    padding: 50px 0;
-    text-align: center;
-}
-
-.contact-section h2 {
-    font-size: 32px;
-    margin-bottom: 12px;
-}
-
-.contact-subtitle {
-    font-size: 14px;
-    color: var(--gray-text);
-    margin-bottom: 30px;
+    color: #3a3a3c;
+    background: rgba(255, 255, 255, 0.8);
 }
 
 .contact-links {
+    margin-top: 12px;
     display: flex;
-    justify-content: center;
-    gap: 12px;
     flex-wrap: wrap;
+    gap: 10px;
 }
 
-.contact-btn {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 10px 18px;
-    background: rgba(0, 212, 255, 0.08);
-    border: 1px solid var(--primary);
-    border-radius: 6px;
-    color: var(--primary);
+.contact-links a {
     text-decoration: none;
-    font-weight: 600;
-    font-size: 13px;
-    transition: all 0.3s ease;
+    color: var(--accent);
+    border: 1px solid rgba(0, 113, 227, 0.2);
+    background: rgba(0, 113, 227, 0.06);
+    border-radius: 999px;
+    padding: 8px 14px;
+    font-size: 14px;
 }
 
-.contact-btn:hover {
-    background: var(--primary);
-    color: var(--dark-bg);
-    transform: translateY(-2px);
-}
-
-.contact-icon {
-    font-size: 16px;
-}
-
-/* 页脚 */
 .footer {
-    padding: 30px 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
     text-align: center;
-    color: var(--gray-text);
-    font-size: 13px;
+    font-size: 12px;
+    color: var(--muted);
+    padding: 20px 8px 8px;
 }
 
-/* 响应式 */
-@media (max-width: 768px) {
-    .hero {
-        grid-template-columns: 1fr;
-        padding: 40px 0;
-        gap: 30px;
+@media (max-width: 680px) {
+    .container {
+        padding: 16px;
     }
 
-    .hero-content h1 {
-        font-size: 36px;
-    }
-
-    .hero-visual {
-        display: none;
-    }
-
-    .nav-links {
-        gap: 20px;
-        font-size: 13px;
-    }
-
-    .about-content {
-        grid-template-columns: 1fr;
-        gap: 30px;
-    }
-
-    .contact-links {
-        flex-direction: column;
-    }
-
-    .contact-btn {
-        width: 100%;
-        justify-content: center;
-    }
-}
-
-@media (max-width: 480px) {
-    .navbar {
-        flex-direction: column;
-        gap: 12px;
-    }
-
-    .nav-links {
+    .topbar {
         flex-direction: column;
         gap: 10px;
+        top: 8px;
     }
 
-    .hero-content h1 {
-        font-size: 28px;
+    .hero,
+    .section {
+        padding: 24px;
+        border-radius: 22px;
     }
 
-    .hero-cta {
+    .hero-cta,
+    .contact-links {
         flex-direction: column;
-        gap: 8px;
-    }
-
-    .btn {
-        width: 100%;
-        text-align: center;
-    }
-
-    .about-section h2,
-    .contact-section h2 {
-        font-size: 26px;
     }
 }


### PR DESCRIPTION
### Motivation
- 将此前通用极简主页基于反馈进一步调整为 Apple 风格：克制灰白配色、玻璃拟态卡片、圆角与细边框以提升现代感与可读性。 
- 精简视觉与交互，保留核心信息（简介、技能、联系方式）并优化移动端表现以提高一致性和专业感。 

### Description
- 重构 `index.html`，简化 DOM 结构为顶部 `header.topbar`、`main`（`section.hero`, `section#skills`, `section#contact`）与底部 `footer`，并更新文案与链接表述。 
- 完全重写 `styles.css`，引入配色变量（如 `--bg`, `--surface`, `--accent` 等）、玻璃拟态样式、柔和阴影与圆角，并统一按钮、chips 与联系方式的视觉规则与响应式断点。 
- 精简 `script.js`，仅保留锚点平滑滚动逻辑并移除页面加载动画与导航滚动变色逻辑以减少复杂交互。 

### Testing
- 已运行 `node --check script.js` 验证脚本语法，结果通过（成功）。 
- 已使用 `python3 -m http.server 4173 --bind 127.0.0.1` 并通过 `curl -I http://127.0.0.1:4173/index.html` 验证页面可访问并返回 `HTTP/1.0 200 OK`（成功）。 
- 尝试使用 Playwright 生成截图，但在当前环境中 Chromium 启动发生 SIGSEGV 崩溃，无法生成截图（失败）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d173268248322ab37e1c74ab71fdc)